### PR TITLE
Some formatting, PHP7.4 support, simplifications, making Home translatable

### DIFF
--- a/Block/Evercrumbs.php
+++ b/Block/Evercrumbs.php
@@ -45,6 +45,9 @@ class Evercrumbs extends Template
             ->setPageSize(1);
 
         $breadcrumbCategories = $categoryCollection->getFirstItem()->getParentCategories();
+        usort($breadcrumbCategories, function ($a, $b) {
+            return strcmp($a->getLevel(), $b->getLevel());
+        });
         foreach ($breadcrumbCategories as $category) {
             $crumbs[] = [
                 'label' => $category->getName(),

--- a/Block/Evercrumbs.php
+++ b/Block/Evercrumbs.php
@@ -1,69 +1,64 @@
 <?php
+
 namespace Harrigo\EverCrumbs\Block;
 
 use Magento\Catalog\Helper\Data;
-use Magento\Framework\View\Element\Template\Context;
-use Magento\Store\Model\Store;
 use Magento\Framework\Registry;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
 
-class Evercrumbs extends \Magento\Framework\View\Element\Template
+class Evercrumbs extends Template
 {
+    protected ?Data $catalogData = null;
+    private Registry $registry;
 
-    /**
-     * Catalog data
-     *
-     * @var Data
-     */
-    protected $_catalogData = null;
-
-    /**
-     * @param Context $context
-     * @param Data $catalogData
-     * @param array $data
-     */
     public function __construct(
-		Context $context, 
-		Data $catalogData, 
-		Registry $registry,
-		array $data = [])
-    {
-        $this->_catalogData = $catalogData;	
-		$this->registry = $registry;
+        Context $context,
+        Data $catalogData,
+        Registry $registry,
+        array $data = []
+    ) {
+        $this->catalogData = $catalogData;
+        $this->registry = $registry;
         parent::__construct($context, $data);
     }
 
-	public function getCrumbs()
+    private function getRootCategoryId(): int
     {
-		$evercrumbs = array();
-		
-		$evercrumbs[] = array(
-			'label' => 'Home',
-			'title' => 'Go to Home Page',
-			'link' => $this->_storeManager->getStore()->getBaseUrl()
-		);
+        return (int) $this->_storeManager->getStore()->getRootCategoryId();
+    }
 
-		$path = $this->_catalogData->getBreadcrumbPath();
-		$product = $this->registry->registry('current_product');
-		$categoryCollection = clone $product->getCategoryCollection();
-		$categoryCollection->clear();
-		$categoryCollection->addAttributeToSort('level', $categoryCollection::SORT_ORDER_DESC)->addAttributeToFilter('path', array('like' => "1/" . $this->_storeManager->getStore()->getRootCategoryId() . "/%"));
-		$categoryCollection->setPageSize(1);
-		$breadcrumbCategories = $categoryCollection->getFirstItem()->getParentCategories();
-		foreach ($breadcrumbCategories as $category) {
-			$evercrumbs[] = array(
-				'label' => $category->getName(),
-				'title' => $category->getName(),
-				'link' => $category->getUrl()
-			);
-		}
-	
-		
-		$evercrumbs[] = array(
-				'label' => $product->getName(),
-				'title' => $product->getName(),
-				'link' => ''
-			);
-				
-		return $evercrumbs;
+    public function getCrumbs(): array
+    {
+        $crumbs = [];
+        $crumbs[] = [
+            'label' => __('Home'),
+            'title' => __('Go to Home Page'),
+            'link' => $this->_storeManager->getStore()->getBaseUrl()
+        ];
+
+        $product = $this->registry->registry('current_product');
+        $categoryCollection = clone $product->getCategoryCollection();
+        $categoryCollection->clear()
+            ->addAttributeToSort('level', $categoryCollection::SORT_ORDER_DESC)
+            ->addAttributeToFilter('path', ['like' => "1/" . $this->getRootCategoryId() . "/%"])
+            ->setPageSize(1);
+
+        $breadcrumbCategories = $categoryCollection->getFirstItem()->getParentCategories();
+        foreach ($breadcrumbCategories as $category) {
+            $crumbs[] = [
+                'label' => $category->getName(),
+                'title' => $category->getName(),
+                'link'  => $category->getUrl()
+            ];
+        }
+
+        $crumbs[] = [
+            'label' => $product->getName(),
+            'title' => $product->getName(),
+            'link' => ''
+        ];
+
+        return $crumbs;
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Harrigo_EverCrumbs" setup_version="1.0.1"/>
+	<module name="Harrigo_EverCrumbs" setup_version="1.0.2">
+        <sequence>
+            <module name="Magento_Catalog"/>
+        </sequence>
+    </module>
 </config>

--- a/registration.php
+++ b/registration.php
@@ -1,6 +1,9 @@
 <?php
-\Magento\Framework\Component\ComponentRegistrar::register(
-    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
     'Harrigo_EverCrumbs',
     __DIR__
 );

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
-<page>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-	<referenceBlock name="breadcrumbs" remove="true" />
-	<referenceContainer name="page.top">
-		<block class="Harrigo\EverCrumbs\Block\Evercrumbs" name="evercrumbs" as="evercrumbs" template="Harrigo_EverCrumbs::evercrumbs.phtml" />
-	</referenceContainer>
+		<referenceBlock name="breadcrumbs" class="Harrigo\EverCrumbs\Block\Evercrumbs" template="Harrigo_EverCrumbs::evercrumbs.phtml" />
     </body>
 </page>

--- a/view/frontend/templates/evercrumbs.phtml
+++ b/view/frontend/templates/evercrumbs.phtml
@@ -1,5 +1,10 @@
-<?php $crumbs = $block->getCrumbs(); ?>
-<?php if ($crumbs && is_array($crumbs)) : ?>
+<?php
+
+use Harrigo\EverCrumbs\Block\Evercrumbs;
+/** @var Evercrumbs $block */
+
+$crumbs = $block->getCrumbs(); ?>
+<?php if ($crumbs && is_array($crumbs)): ?>
 <?php $i = 0; ?>
 <div class="breadcrumbs">
     <ul class="items" itemscope itemtype="http://schema.org/BreadcrumbList">


### PR DESCRIPTION
Hi @harrigo I saw you extension which solves my problem and did some small changes (it looks like many, but are mainly formatting).

I also fixed problem with re-declared block in xml because my old block was moved in theme and new one did't show in right place. This way new class is assigned for existing block and is shown where it was defined.

Also starting point in breadcrumbs was not translatable.

Once again, Thank you for module.